### PR TITLE
Update README.md (ssh -> https in git clone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ On macOS:
 
 ```
 # clone the repo
-git clone git@github.com:duo-labs/cloudmapper.git
+git clone https://github.com/duo-labs/cloudmapper.git
 # Install pre-reqs for pyjq
 brew install autoconf automake libtool jq awscli python3 pipenv
 cd cloudmapper/
@@ -35,7 +35,7 @@ pipenv shell
 On Linux:
 ```
 # clone the repo
-git clone git@github.com:duo-labs/cloudmapper.git
+git clone https://github.com/duo-labs/cloudmapper.git
 # (AWS Linux, Centos, Fedora, RedHat etc.):
 # sudo yum install autoconf automake libtool python3-devel.x86_64 python3-tkinter python-pip jq awscli
 # (Debian, Ubuntu etc.):


### PR DESCRIPTION
Changed `git clone` instruction in examples to use `https` instead of `ssh`.